### PR TITLE
move foi on map check to inline

### DIFF
--- a/frontend/src/store/modules/AOI.js
+++ b/frontend/src/store/modules/AOI.js
@@ -53,7 +53,7 @@ const AOI = {
                 rootState.ligfinder.FOI=response.data
                 const sourceData = response.data
                 dispatch('map/addFOI2Map',sourceData,{root:true}).then(()=>{
-                    const isFOIonMap = rootGetters['map/isFOIonMap']
+                    const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                     const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                     if (isFOIonMap && !isFOIonLayerList){
                         commit('layers/addFOI2LayerList',null,{root:true})
@@ -78,7 +78,7 @@ const AOI = {
                     rootState.ligfinder.FOI=response.data
                     const sourceData = response.data
                     dispatch('map/addFOI2Map',sourceData,{root:true}).then(()=>{
-                        const isFOIonMap = rootGetters['map/isFOIonMap']
+                        const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                         const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                         if (isFOIonMap && !isFOIonLayerList){
                             commit('layers/addFOI2LayerList',null,{root:true})

--- a/frontend/src/store/modules/administrativeAOI.js
+++ b/frontend/src/store/modules/administrativeAOI.js
@@ -137,7 +137,7 @@ const administrativeAOI = {
                 //update the result table
                 const sourceData = rootState.ligfinder.FOI
                 dispatch('map/addFOI2Map',{sourceData},{root:true}).then(()=>{
-                    const isFOIonMap = rootGetters['map/isFOIonMap']
+                    const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                     const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                     if (isFOIonMap && !isFOIonLayerList){
                     commit('layers/addFOI2LayerList',null,{root:true})

--- a/frontend/src/store/modules/area.js
+++ b/frontend/src/store/modules/area.js
@@ -70,7 +70,7 @@ const area = {
                 commit('layers/updateFOI',{data:state.areaFilterData},{root:true})
                 const sourceData = rootState.ligfinder.FOI
                 dispatch('map/addFOI2Map',sourceData,{root:true}).then(()=>{
-                    const isFOIonMap = rootGetters['map/isFOIonMap']
+                    const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                     const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                     if (isFOIonMap && !isFOIonLayerList){
                         commit('layers/addFOI2LayerList',null,{root:true})

--- a/frontend/src/store/modules/criteria.js
+++ b/frontend/src/store/modules/criteria.js
@@ -78,7 +78,7 @@ const criteria = {
 
                 const sourceData = rootState.ligfinder.FOI
                 dispatch('map/addFOI2Map',sourceData,{root:true}).then(()=>{
-                    const isFOIonMap = rootGetters['map/isFOIonMap']
+                    const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                     const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                     if (isFOIonMap && !isFOIonLayerList){
                         commit('layers/addFOI2LayerList',null,{root:true})

--- a/frontend/src/store/modules/geometryAOI.js
+++ b/frontend/src/store/modules/geometryAOI.js
@@ -58,7 +58,7 @@ const geometryAOI = {
                 commit('layers/updateFOI',{data:response.data},{root:true})
                 const sourceData = rootState.ligfinder.FOI
                 dispatch('map/addFOI2Map',sourceData,{root:true}).then(()=>{
-                    const isFOIonMap = rootGetters['map/isFOIonMap']
+                    const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                     const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                     if (isFOIonMap && !isFOIonLayerList){
                         commit('layers/addFOI2LayerList',null,{root:true})

--- a/frontend/src/store/modules/isochroneAOI.js
+++ b/frontend/src/store/modules/isochroneAOI.js
@@ -144,7 +144,7 @@ const isochroneAOI = {
                 commit('layers/updateFOI',{data:response.data},{root:true})
                 const sourceData = rootState.ligfinder.FOI
                 dispatch('map/addFOI2Map',sourceData,{root:true}).then(()=>{
-                    const isFOIonMap = rootGetters['map/isFOIonMap']
+                    const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                     const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                     if (isFOIonMap && !isFOIonLayerList){
                         commit('layers/addFOI2LayerList',null,{root:true})

--- a/frontend/src/store/modules/layers.js
+++ b/frontend/src/store/modules/layers.js
@@ -69,7 +69,7 @@ const layers = {
        
     },
     actions:{
-        getTableNames({state, rootGetters,commit}){
+        getTableNames({state,rootState,rootGetters,commit}){
             if (state.toggle==true){   /* 
                                                     to avoid sending get request when closing the panel
                                                     */
@@ -82,7 +82,7 @@ const layers = {
                     }
                     state.tableNames = [...tableList,...state.tableNames]
                     
-                    const isFOIonMap = rootGetters['map/isFOIonMap']
+                    const isFOIonMap = typeof rootState.map.map.getLayer("foi") != 'undefined' ? true : false
                     const isFOIonLayerList = rootGetters['layers/isFOIonLayerList']
                     if (isFOIonMap && !isFOIonLayerList){
                     commit('addFOI2LayerList')

--- a/frontend/src/store/modules/map.js
+++ b/frontend/src/store/modules/map.js
@@ -115,9 +115,6 @@ const map=  {
         }
     },
     getters:{
-        isFOIonMap(state){
-            return typeof state.map.getLayer("foi") != 'undefined' ? true : false
-        }
     }
 }
 


### PR DESCRIPTION
checking is foi on map or not via getters not always gives right answer. Because, getters cache their result and if state does not change they give cached result.